### PR TITLE
Makes vue alias path absolute

### DIFF
--- a/scripts/make-webpack-config.js
+++ b/scripts/make-webpack-config.js
@@ -74,7 +74,7 @@ module.exports = function(config, env) {
 			alias: {
 				// allows to use the compiler
 				// without this, cli will overload the alias and use runtime esm
-				vue$: 'vue/dist/vue.esm.js',
+				vue$: require.resolve('vue/dist/vue.esm.js'),
 			},
 		},
 		plugins: [


### PR DESCRIPTION
**Issue:** 
Vue is included twice in *main.bundle.js* when components are included from external package.

**Description:**

I want to have the styleguide separated from the components given a folder structue like that:

```
o
|-- components
|   |-- node_modules
|   |   `-- vue
|   `-- src
`-- styleguide
    |-- node_modules
    |   |-- *components
    |   `-- vue
    `-- src
```

The styleguide package was created by using vue-cli + vue-cli-plugin-styleguidist.

I have components package symlinked into the styleguide modules folder and importing those components like that:

*styleguide.config.js*
```
function resolveComponents(path) {
  return path.resolve(path.dirname(require.resolve('components/package.json')), path);
};

sections: [
  {
    name: 'Components',
    components: resolveComponents('src/components/**/*.vue')
  },
]
```
Now, when I look into the browser console (or main.bundle.js) I see that Vue is included and running twice.
After some investigation I found out that in such case webpack is using a project relative version of vue because of:
```
alias: {
  // allows to use the compiler
  // without this, cli will overload the alias and use runtime esm
  vue$: 'vue/dist/vue.esm.js',
},
```
Changing this into an absolute path using `require.resolve()` solved that problem for me.

I'm not a webpack pro or something but is there a reason to have it relative?